### PR TITLE
Fixes invalid size parameter for LineBasicMaterial

### DIFF
--- a/src/markers/Marker.js
+++ b/src/markers/Marker.js
@@ -100,7 +100,7 @@ ROS3D.Marker = function(options) {
     case ROS3D.MARKER_LINE_STRIP:
       var lineStripGeom = new THREE.Geometry();
       var lineStripMaterial = new THREE.LineBasicMaterial({
-        size : message.scale.x
+        linewidth : message.scale.x
       });
 
       // add the points
@@ -131,7 +131,7 @@ ROS3D.Marker = function(options) {
     case ROS3D.MARKER_LINE_LIST:
       var lineListGeom = new THREE.Geometry();
       var lineListMaterial = new THREE.LineBasicMaterial({
-        size : message.scale.x
+        linewidth : message.scale.x
       });
 
       // add the points


### PR DESCRIPTION
Simple fix to a invalid parameter warning when generating a Marker with a threejs LineBasicMaterial.

This is minor, but it resolves a lot of unnecessary warnings when generating a lot of line-based markers.